### PR TITLE
Remove clock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "usbd-human-interface-device"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 description = "Batteries included embedded USB HID library for usb-device. Includes concrete Keyboard (boot and NKRO), Mouse and Consumer Control implementations as well as support for building your own HID classes."
 keywords = [ "hid", "usb-device", "usb", "keyboard", "mouse"]

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
 dependencies = [
  "memchr",
 ]
@@ -313,9 +313,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "lock_api"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
+checksum = "9f80bf5aacaf25cbfc8210d1cfb718f2bf3b11c4c54e5afe36c236853a8ec390"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -467,9 +467,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9423e2b32f7a043629287a536f21951e8c6a82482d0acb1eeebfc90bc2225b22"
+checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
 
 [[package]]
 name = "pio"
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "usbd-human-interface-device"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "delegate",
  "embedded-time",

--- a/examples/src/bin/keyboard_boot.rs
+++ b/examples/src/bin/keyboard_boot.rs
@@ -9,10 +9,8 @@ use cortex_m::prelude::*;
 use defmt::*;
 use defmt_rtt as _;
 use embedded_hal::digital::v2::*;
-use embedded_time::duration::{Fraction, Milliseconds};
-use embedded_time::Instant;
+use embedded_time::duration::Milliseconds;
 use hal::pac;
-use hal::Timer;
 use panic_probe as _;
 use usb_device::class_prelude::*;
 use usb_device::prelude::*;
@@ -20,25 +18,6 @@ use usbd_human_interface_device::page::Keyboard;
 use usbd_human_interface_device::prelude::*;
 
 use rp_pico as bsp;
-
-pub struct TimerClock<'a> {
-    timer: &'a Timer,
-}
-
-impl<'a> TimerClock<'a> {
-    pub fn new(timer: &'a Timer) -> Self {
-        Self { timer }
-    }
-}
-
-impl<'a> embedded_time::clock::Clock for TimerClock<'a> {
-    type T = u32;
-    const SCALING_FACTOR: Fraction = Fraction::new(1, 1_000_000u32);
-
-    fn try_now(&self) -> Result<Instant<Self>, embedded_time::clock::Error> {
-        Ok(Instant::new(self.timer.get_counter_low()))
-    }
-}
 
 #[entry]
 fn main() -> ! {
@@ -58,7 +37,6 @@ fn main() -> ! {
     .unwrap();
 
     let timer = hal::Timer::new(pac.TIMER, &mut pac.RESETS);
-    let clock = TimerClock::new(&timer);
 
     let sio = hal::Sio::new(pac.SIO);
     let pins = hal::gpio::Pins::new(
@@ -81,9 +59,7 @@ fn main() -> ! {
 
     let mut keyboard = UsbHidClassBuilder::new()
         .add_interface(
-            usbd_human_interface_device::device::keyboard::BootKeyboardInterface::default_config(
-                &clock,
-            ),
+            usbd_human_interface_device::device::keyboard::BootKeyboardInterface::default_config(),
         )
         .build(&usb_bus);
 

--- a/examples/src/bin/keyboard_nkro.rs
+++ b/examples/src/bin/keyboard_nkro.rs
@@ -9,10 +9,7 @@ use defmt_rtt as _;
 use embedded_hal::digital::v2::*;
 use embedded_hal::prelude::*;
 use embedded_time::duration::Milliseconds;
-use embedded_time::rate::Fraction;
-use embedded_time::Instant;
 use hal::pac;
-use hal::Timer;
 use panic_probe as _;
 use usb_device::class_prelude::*;
 use usb_device::prelude::*;
@@ -20,25 +17,6 @@ use usbd_human_interface_device::page::Keyboard;
 use usbd_human_interface_device::prelude::*;
 
 use rp_pico as bsp;
-
-pub struct TimerClock<'a> {
-    timer: &'a Timer,
-}
-
-impl<'a> TimerClock<'a> {
-    pub fn new(timer: &'a Timer) -> Self {
-        Self { timer }
-    }
-}
-
-impl<'a> embedded_time::clock::Clock for TimerClock<'a> {
-    type T = u32;
-    const SCALING_FACTOR: Fraction = Fraction::new(1, 1_000_000u32);
-
-    fn try_now(&self) -> Result<Instant<Self>, embedded_time::clock::Error> {
-        Ok(Instant::new(self.timer.get_counter_low()))
-    }
-}
 
 #[entry]
 fn main() -> ! {
@@ -67,8 +45,6 @@ fn main() -> ! {
         &mut pac.RESETS,
     );
 
-    let clock = TimerClock::new(&timer);
-
     info!("Starting");
 
     //USB
@@ -82,7 +58,7 @@ fn main() -> ! {
 
     let mut keyboard = UsbHidClassBuilder::new()
         .add_interface(
-            usbd_human_interface_device::device::keyboard::NKROBootKeyboardInterface::default_config(&clock),
+            usbd_human_interface_device::device::keyboard::NKROBootKeyboardInterface::default_config(),
         )
         .build(&usb_bus);
 

--- a/src/device/keyboard.rs
+++ b/src/device/keyboard.rs
@@ -23,6 +23,7 @@ where
 {
     delegate! {
         to self.inner {
+            /// Call every 1ms / at 1 KHz
             pub fn tick(&self) -> Result<(), UsbHidError>;
         }
     }
@@ -403,6 +404,7 @@ where
 {
     delegate! {
         to self.inner {
+            /// Call every 1ms / at 1 KHz
             pub fn tick(&self) -> Result<(), UsbHidError>;
         }
     }

--- a/src/device/keyboard.rs
+++ b/src/device/keyboard.rs
@@ -2,7 +2,6 @@
 
 use delegate::delegate;
 use embedded_time::duration::Milliseconds;
-use embedded_time::{Clock, TimeInt};
 use packed_struct::prelude::*;
 use usb_device::class_prelude::*;
 use usb_device::UsbError;
@@ -14,16 +13,13 @@ use crate::page::Keyboard;
 use crate::UsbHidError;
 
 /// Interface implementing the HID boot keyboard specification
-pub struct BootKeyboardInterface<'a, B: UsbBus, C: embedded_time::Clock> {
-    inner: ManagedInterface<'a, B, C, BootKeyboardReport>,
+pub struct BootKeyboardInterface<'a, B: UsbBus> {
+    inner: ManagedInterface<'a, B, BootKeyboardReport>,
 }
 
-impl<'a, B, C, Tick> BootKeyboardInterface<'a, B, C>
+impl<'a, B> BootKeyboardInterface<'a, B>
 where
     B: UsbBus,
-    C: embedded_time::Clock<T = Tick>,
-    Tick: TimeInt,
-    u32: TryFrom<Tick>,
 {
     delegate! {
         to self.inner {
@@ -52,8 +48,7 @@ where
     }
 
     pub fn default_config(
-        clock: &'a C,
-    ) -> WrappedInterfaceConfig<Self, ManagedInterfaceConfig<'a, C, BootKeyboardReport>> {
+    ) -> WrappedInterfaceConfig<Self, ManagedInterfaceConfig<'a, BootKeyboardReport>> {
         WrappedInterfaceConfig::new(
             ManagedInterfaceConfig::new(
                 RawInterfaceBuilder::new(BOOT_KEYBOARD_REPORT_DESCRIPTOR)
@@ -68,19 +63,15 @@ where
                     .with_out_endpoint(UsbPacketSize::Bytes8, Milliseconds(100))
                     .unwrap()
                     .build(),
-                clock,
             ),
             (),
         )
     }
 }
 
-impl<'a, B, C, Tick> InterfaceClass<'a> for BootKeyboardInterface<'a, B, C>
+impl<'a, B> InterfaceClass<'a> for BootKeyboardInterface<'a, B>
 where
     B: UsbBus,
-    C: embedded_time::Clock<T = Tick>,
-    Tick: TimeInt,
-    u32: TryFrom<Tick>,
 {
     delegate! {
         to self.inner{
@@ -100,15 +91,12 @@ where
     }
 }
 
-impl<'a, B, C, Tick> WrappedInterface<'a, B, ManagedInterface<'a, B, C, BootKeyboardReport>>
-    for BootKeyboardInterface<'a, B, C>
+impl<'a, B> WrappedInterface<'a, B, ManagedInterface<'a, B, BootKeyboardReport>>
+    for BootKeyboardInterface<'a, B>
 where
     B: UsbBus,
-    C: embedded_time::Clock<T = Tick>,
-    Tick: TimeInt,
-    u32: TryFrom<Tick>,
 {
-    fn new(interface: ManagedInterface<'a, B, C, BootKeyboardReport>, _: ()) -> Self {
+    fn new(interface: ManagedInterface<'a, B, BootKeyboardReport>, _: ()) -> Self {
         Self { inner: interface }
     }
 }
@@ -405,16 +393,13 @@ impl NKROBootKeyboardReport {
 }
 
 /// Interface implementing a NKRO keyboard compatible with the HID boot keyboard specification
-pub struct NKROBootKeyboardInterface<'a, B: UsbBus, C: embedded_time::Clock> {
-    inner: ManagedInterface<'a, B, C, NKROBootKeyboardReport>,
+pub struct NKROBootKeyboardInterface<'a, B: UsbBus> {
+    inner: ManagedInterface<'a, B, NKROBootKeyboardReport>,
 }
 
-impl<'a, B, C, Tick> NKROBootKeyboardInterface<'a, B, C>
+impl<'a, B> NKROBootKeyboardInterface<'a, B>
 where
     B: UsbBus,
-    C: embedded_time::Clock<T = Tick>,
-    Tick: TimeInt,
-    u32: TryFrom<Tick>,
 {
     delegate! {
         to self.inner {
@@ -443,8 +428,7 @@ where
     }
 
     pub fn default_config(
-        clock: &'a C,
-    ) -> WrappedInterfaceConfig<Self, ManagedInterfaceConfig<'a, C, NKROBootKeyboardReport>> {
+    ) -> WrappedInterfaceConfig<Self, ManagedInterfaceConfig<'a, NKROBootKeyboardReport>> {
         WrappedInterfaceConfig::new(
             ManagedInterfaceConfig::new(
                 RawInterfaceBuilder::new(NKRO_BOOT_KEYBOARD_REPORT_DESCRIPTOR)
@@ -457,19 +441,15 @@ where
                     .with_out_endpoint(UsbPacketSize::Bytes8, Milliseconds(100))
                     .unwrap()
                     .build(),
-                clock,
             ),
             (),
         )
     }
 }
 
-impl<'a, B, C, Tick> InterfaceClass<'a> for NKROBootKeyboardInterface<'a, B, C>
+impl<'a, B> InterfaceClass<'a> for NKROBootKeyboardInterface<'a, B>
 where
     B: UsbBus,
-    C: embedded_time::Clock<T = Tick>,
-    Tick: TimeInt,
-    u32: TryFrom<Tick>,
 {
     delegate! {
         to self.inner{
@@ -489,15 +469,12 @@ where
     }
 }
 
-impl<'a, B, C, Tick> WrappedInterface<'a, B, ManagedInterface<'a, B, C, NKROBootKeyboardReport>>
-    for NKROBootKeyboardInterface<'a, B, C>
+impl<'a, B> WrappedInterface<'a, B, ManagedInterface<'a, B, NKROBootKeyboardReport>>
+    for NKROBootKeyboardInterface<'a, B>
 where
     B: 'a + UsbBus,
-    C: 'a + Clock<T = Tick>,
-    Tick: TimeInt,
-    u32: TryFrom<Tick>,
 {
-    fn new(interface: ManagedInterface<'a, B, C, NKROBootKeyboardReport>, _: ()) -> Self {
+    fn new(interface: ManagedInterface<'a, B, NKROBootKeyboardReport>, _: ()) -> Self {
         Self { inner: interface }
     }
 }


### PR DESCRIPTION
Remove the `embedded_time::Clock` reference required by managed interfaces and change to a 1kHz tick() method