### PR TITLE
Remove unnecessary reference when iterating over page::Keyboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,18 +49,18 @@ tick_timer.start(1.millis());
 
 loop {
     let keys = if pin.is_high().unwrap() {
-            &[Keyboard::A]
+            [Keyboard::A]
         } else {
-            &[Keyboard::NoEventIndicated]
+            [Keyboard::NoEventIndicated]
     };
-    
+
     keyboard.interface().write_report(keys).ok();
 
     //tick once per ms/at 1kHz
     if tick_timer.wait().is_ok() {
         keyboard.interface().tick().unwrap();
     }
-    
+
     if usb_dev.poll(&mut [&mut keyboard]) {
         match keyboard.interface().read_report() {
 

--- a/examples/src/bin/composite.rs
+++ b/examples/src/bin/composite.rs
@@ -133,7 +133,7 @@ fn main() -> ! {
             let keys = get_keyboard_keys(key_pins);
 
             let keyboard = composite.interface::<NKROBootKeyboardInterface<'_, _>, _>();
-            match keyboard.write_report(&keys) {
+            match keyboard.write_report(keys) {
                 Err(UsbHidError::WouldBlock) => {}
                 Err(UsbHidError::Duplicate) => {}
                 Ok(_) => {}

--- a/examples/src/bin/composite_irq.rs
+++ b/examples/src/bin/composite_irq.rs
@@ -161,7 +161,7 @@ fn main() -> ! {
                 let keys = get_keyboard_keys(key_pins);
 
                 let keyboard = composite.interface::<NKROBootKeyboardInterface<'_, _>, _>();
-                match keyboard.write_report(&keys) {
+                match keyboard.write_report(keys) {
                     Err(UsbHidError::WouldBlock) => {}
                     Err(UsbHidError::Duplicate) => {}
                     Ok(_) => {}

--- a/examples/src/bin/keyboard_boot.rs
+++ b/examples/src/bin/keyboard_boot.rs
@@ -99,7 +99,7 @@ fn main() -> ! {
         if input_count_down.wait().is_ok() {
             let keys = get_keys(keys);
 
-            match keyboard.interface().write_report(&keys) {
+            match keyboard.interface().write_report(keys) {
                 Err(UsbHidError::WouldBlock) => {}
                 Err(UsbHidError::Duplicate) => {}
                 Ok(_) => {}

--- a/examples/src/bin/keyboard_custom.rs
+++ b/examples/src/bin/keyboard_custom.rs
@@ -165,7 +165,7 @@ fn main() -> ! {
             if last_keys.map(|k| k != keys).unwrap_or(true) {
                 match keyboard
                     .interface()
-                    .write_report(&BootKeyboardReport::new(&keys).pack().unwrap())
+                    .write_report(&BootKeyboardReport::new(keys).pack().unwrap())
                 {
                     Err(UsbError::WouldBlock) => {}
                     Ok(_) => {

--- a/examples/src/bin/keyboard_nkro.rs
+++ b/examples/src/bin/keyboard_nkro.rs
@@ -101,7 +101,7 @@ fn main() -> ! {
         if input_count_down.wait().is_ok() {
             let keys = get_keys(keys);
 
-            match keyboard.interface().write_report(&keys) {
+            match keyboard.interface().write_report(keys) {
                 Err(UsbHidError::WouldBlock) => {}
                 Err(UsbHidError::Duplicate) => {}
                 Ok(_) => {}

--- a/src/device/keyboard.rs
+++ b/src/device/keyboard.rs
@@ -30,7 +30,7 @@ where
         }
     }
 
-    pub fn write_report<'b, K: IntoIterator<Item = &'b Keyboard>>(
+    pub fn write_report<K: IntoIterator<Item = Keyboard>>(
         &self,
         keys: K,
     ) -> Result<(), UsbHidError> {
@@ -145,7 +145,7 @@ pub struct BootKeyboardReport {
 }
 
 impl BootKeyboardReport {
-    pub fn new<'a, K: IntoIterator<Item = &'a Keyboard>>(keys: K) -> Self {
+    pub fn new<K: IntoIterator<Item = Keyboard>>(keys: K) -> Self {
         let mut report = Self::default();
 
         let mut error = false;
@@ -181,7 +181,7 @@ impl BootKeyboardReport {
                     if !error {
                         error = true;
                         i = report.keys.len();
-                        report.keys.fill(*k);
+                        report.keys.fill(k);
                     }
                 }
                 _ => {
@@ -190,7 +190,7 @@ impl BootKeyboardReport {
                     }
 
                     if i < report.keys.len() {
-                        report.keys[i] = *k;
+                        report.keys[i] = k;
                         i += 1;
                     } else {
                         error = true;
@@ -205,7 +205,7 @@ impl BootKeyboardReport {
 }
 
 /// HID Keyboard report descriptor conforming to the Boot specification
-/// 
+///
 /// This aims to be compatible with BIOS and other reduced functionality USB hosts
 ///
 /// This is defined in Appendix B.1 & E.6 of [Device Class Definition for Human
@@ -328,7 +328,7 @@ pub struct NKROBootKeyboardReport {
 }
 
 impl NKROBootKeyboardReport {
-    pub fn new<'a, K: IntoIterator<Item = &'a Keyboard>>(keys: K) -> Self {
+    pub fn new<K: IntoIterator<Item = Keyboard>>(keys: K) -> Self {
         let mut report = Self::default();
 
         let mut boot_keys_error = false;
@@ -361,18 +361,18 @@ impl NKROBootKeyboardReport {
                 }
                 Keyboard::NoEventIndicated => {}
                 Keyboard::ErrorRollOver | Keyboard::POSTFail | Keyboard::ErrorUndefine => {
-                    report.nkro_keys[0] |= 1 << *k as u8;
+                    report.nkro_keys[0] |= 1 << k as u8;
 
                     if !boot_keys_error {
                         boot_keys_error = true;
                         i = report.boot_keys.len();
-                        report.boot_keys.fill(*k);
+                        report.boot_keys.fill(k);
                     }
                 }
                 _ => {
-                    if (*k as usize) < report.nkro_keys.len() * 8 {
-                        let byte = (*k as usize) / 8;
-                        let bit = (*k as u8) % 8;
+                    if (k as usize) < report.nkro_keys.len() * 8 {
+                        let byte = (k as usize) / 8;
+                        let bit = (k as u8) % 8;
                         report.nkro_keys[byte] |= 1 << bit;
                     }
 
@@ -381,7 +381,7 @@ impl NKROBootKeyboardReport {
                     }
 
                     if i < report.boot_keys.len() {
-                        report.boot_keys[i] = *k;
+                        report.boot_keys[i] = k;
                         i += 1;
                     } else {
                         boot_keys_error = true;
@@ -413,7 +413,7 @@ where
         }
     }
 
-    pub fn write_report<'b, K: IntoIterator<Item = &'b Keyboard>>(
+    pub fn write_report<K: IntoIterator<Item = Keyboard>>(
         &self,
         keys: K,
     ) -> Result<(), UsbHidError> {
@@ -486,7 +486,7 @@ where
 }
 
 /// HID Keyboard report descriptor implementing an NKRO keyboard as a bitmap.
-/// 
+///
 /// N.B. This is not compatible with the HID boot specification
 //18 bytes - derived from https://learn.adafruit.com/custom-hid-devices-in-circuitpython/n-key-rollover-nkro-hid-device
 //First byte modifiers, 17 byte key bit array
@@ -575,7 +575,7 @@ mod test {
 
     #[test]
     fn boot_keyboard_report_mixed() {
-        let bytes = BootKeyboardReport::new(&[
+        let bytes = BootKeyboardReport::new([
             Keyboard::LeftAlt,
             Keyboard::A,
             Keyboard::B,
@@ -603,7 +603,7 @@ mod test {
 
     #[test]
     fn boot_keyboard_report_keys() {
-        let bytes = BootKeyboardReport::new(&[
+        let bytes = BootKeyboardReport::new([
             Keyboard::A,
             Keyboard::B,
             Keyboard::C,
@@ -631,7 +631,7 @@ mod test {
 
     #[test]
     fn boot_keyboard_report_rollover() {
-        let bytes = BootKeyboardReport::new(&[
+        let bytes = BootKeyboardReport::new([
             Keyboard::LeftAlt,
             Keyboard::A,
             Keyboard::B,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,18 +112,18 @@
 //!
 //! loop {
 //!     let keys = if pin.is_high().unwrap() {
-//!             &[Keyboard::A]
+//!             [Keyboard::A]
 //!         } else {
-//!             &[Keyboard::NoEventIndicated]
+//!             [Keyboard::NoEventIndicated]
 //!     };
-//!     
+//!
 //!     keyboard.interface().write_report(keys).ok();
 //!
 //!     //tick once per ms/at 1kHz
 //!     if tick_timer.wait().is_ok() {
 //!         keyboard.interface().tick().unwrap();
 //!     }
-//!     
+//!
 //!     if usb_dev.poll(&mut [&mut keyboard]) {
 //!         match keyboard.interface().read_report() {
 //!


### PR DESCRIPTION
All the enums in [page.rs](https://github.com/dlkj/usbd-human-interface-device/blob/main/src/page.rs) are `Copy` and `repr(u8)`/`repr(u16)` so it is more efficient to copy these by value than to use references. I didn't check if this pointer indirection actually gets optimized out by the compiler, but even if it is optimized out, this change simplifies implementation, by removing the additional lifetime. This way it is easier to implement iterator conversion, e.g. when converting [keyberon::KeyCode](https://github.com/TeXitoi/keyberon/blob/03542891e9fac096b72bf45316992d20b39ba335/src/key_code.rs#L8) to `page::Keyboard`. An example implementation of this conversion would be:
```rust
// This is just a PoC, the code could be cleaner and use some extension trait 
pub struct KeyboardIter<I> {
    pub iter: I,
}

impl<I> Iterator for KeyboardIter<I>
    where I: Iterator<Item = KeyCode>
{
    type Item = usb_hid::page::Keyboard;

    fn next(&mut self) -> Option<Self::Item> {
        self.iter.next()
            .map(|kc| (kc as u8).into())
    }
}

// then use it like
let report = BootKeyboardReport::new(KeyboardIter { iter: layout.keycodes() })
// or to write report
keyboard_interface.write_report(KeyboardIter { iter: layout.keycodes() })
```

This would solve the problem mentioned in https://github.com/TeXitoi/keyberon/pull/99 (though I think the PR is still valid but for the reason described in the last sentence of [my comment](https://github.com/TeXitoi/keyberon/pull/99#issuecomment-1311628157)), and would allow @ithinuel to avoid [creating large intermediate array](https://github.com/ithinuel/wilskeeb/blob/52416e72f993a381d796b8141d895e094458df35/firmware/src/main.rs#L336).

I would also say, that it would be better to just require passing `&BootKeyboardReport` [here](https://github.com/dlkj/usbd-human-interface-device/blob/f8feb2a384ea7df425dd99d89ac590d574c904fb/src/device/keyboard.rs#L35) instead of generic `IntoIterator` (same for `NKROBootKeyboardInterface::write_report`). This would be more consistent with other interfaces (e.g. [ConsumerControlInterface](https://github.com/dlkj/usbd-human-interface-device/blob/f8feb2a384ea7df425dd99d89ac590d574c904fb/src/device/consumer.rs#L99)) and it gives the user more control over the process of report creation/management, while it is still very easy to just write `BootKeyboardReport::new(keys)` directly if needed. 