### PR TITLE
Avoid pulling core::fmt for PackingError when unwrapping

### DIFF
--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -68,10 +68,7 @@ pub trait InterfaceClass<'a> {
     fn hid_descriptor_body(&self) -> [u8; 7] {
         let descriptor_len = self.report_descriptor().len();
         if descriptor_len > u16::MAX as usize {
-            panic!(
-                "Report descriptor length {:X} too long to fit in u16",
-                descriptor_len
-            );
+            panic!("Report descriptor too long");
         } else {
             HidDescriptorBody {
                 bcd_hid: SPEC_VERSION_1_11,
@@ -81,6 +78,7 @@ pub trait InterfaceClass<'a> {
                 descriptor_length: descriptor_len as u16,
             }
             .pack()
+            .map_err(drop) // Avoid pulling all the core::fmt code into final binary
             .expect("Failed to pack HidDescriptor")
         }
     }


### PR DESCRIPTION
In [my comment](https://github.com/dlkj/usbd-human-interface-device/issues/73#issuecomment-1315268711) I said that all the `fmt` was being pulled due to my application code, but I actually didn't notice that I was testing with slight modifications to `usbd-human-interface-device`. I reviewed my changes and it looks like `fmt` was being pulled due to `.pack().expect(...)` (besides my unwrapping of `UsbHidError`). 

This PR fixes the problem by dropping the `PackingError` before calling `expect`. I also included a minor fix that avoids hex formatting in one `panic!`. I think that the fixed-string message should give enough context (you could add `log::error!` if more context is needed).