### PR TITLE
Increase visibility of ConsumerControl*Config::new

### DIFF
--- a/src/device/consumer.rs
+++ b/src/device/consumer.rs
@@ -121,7 +121,8 @@ pub struct ConsumerControlConfig<'a> {
 }
 
 impl<'a> ConsumerControlConfig<'a> {
-    fn new(interface: InterfaceConfig<'a, InBytes8, OutNone, ReportSingle>) -> Self {
+    #[must_use]
+    pub fn new(interface: InterfaceConfig<'a, InBytes8, OutNone, ReportSingle>) -> Self {
         Self { interface }
     }
 }
@@ -183,7 +184,8 @@ pub struct ConsumerControlFixedConfig<'a> {
     interface: InterfaceConfig<'a, InBytes8, OutNone, ReportSingle>,
 }
 impl<'a> ConsumerControlFixedConfig<'a> {
-    fn new(interface: InterfaceConfig<'a, InBytes8, OutNone, ReportSingle>) -> Self {
+    #[must_use]
+    pub fn new(interface: InterfaceConfig<'a, InBytes8, OutNone, ReportSingle>) -> Self {
         Self { interface }
     }
 }


### PR DESCRIPTION
I think these were meant to be `pub` in the first place, since the constructors for the other config types are also public.