### PR TITLE
Allow static descriptors and reject long dynamic descriptors

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -539,9 +539,9 @@ dependencies = [
 
 [[package]]
 name = "rp2040-hal"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ec610f738b69100fbe75f3b835501b669d41c889ac9a62ef284f8e6d1f17385"
+checksum = "08f21deadb5f29f05be9e665049c9c6d6385c6ed3437574c995658a041f71453"
 dependencies = [
  "cortex-m",
  "critical-section",

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -62,7 +62,7 @@ where
 
 pub trait InterfaceClass<'a> {
     fn hid_descriptor_body(&self) -> [u8; 7];
-    fn report_descriptor(&self) -> &'_ [u8];
+    fn report_descriptor(&self) -> ReportDescriptor<'_>;
     fn id(&self) -> InterfaceNumber;
     fn write_descriptors(&self, writer: &mut DescriptorWriter) -> usb_device::Result<()>;
     fn get_string(&self, index: StringIndex, _lang_id: u16) -> Option<&'a str>;
@@ -240,6 +240,12 @@ option_block_idle_storage!(Reports64, Block64);
 option_block_idle_storage!(Reports128, Block128);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReportDescriptor<'a> {
+    StaticDescriptor(&'static [u8]),
+    DynamicDescriptor(&'a [u8]),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct InterfaceConfig<'a, I, O, R>
 where
     I: InSize,
@@ -247,7 +253,7 @@ where
     R: ReportCount,
 {
     marker: PhantomData<(I, O, R)>,
-    report_descriptor: &'a [u8],
+    report_descriptor: ReportDescriptor<'a>,
     report_descriptor_length: u16,
     description: Option<&'a str>,
     protocol: InterfaceProtocol,
@@ -433,7 +439,7 @@ where
         }
     }
 
-    fn report_descriptor(&self) -> &'_ [u8] {
+    fn report_descriptor(&self) -> ReportDescriptor<'_> {
         self.config.report_descriptor
     }
 
@@ -586,10 +592,30 @@ where
     R: ReportCount,
 {
     pub fn new(report_descriptor: &'a [u8]) -> BuilderResult<Self> {
+        if report_descriptor.len() > 128 {
+            return Err(UsbHidBuilderError::SliceLengthOverflow);
+        }
+
         Ok(InterfaceBuilder {
             config: InterfaceConfig {
                 marker: PhantomData,
-                report_descriptor,
+                report_descriptor: ReportDescriptor::DynamicDescriptor(report_descriptor),
+                report_descriptor_length: u16::try_from(report_descriptor.len())
+                    .map_err(|_| UsbHidBuilderError::SliceLengthOverflow)?,
+                description: None,
+                protocol: InterfaceProtocol::None,
+                idle_default: 0,
+                out_endpoint: None,
+                in_endpoint: EndpointConfig { poll_interval: 20 },
+            },
+        })
+    }
+
+    pub fn with_static_descriptor(report_descriptor: &'static [u8]) -> BuilderResult<Self> {
+        Ok(InterfaceBuilder {
+            config: InterfaceConfig {
+                marker: PhantomData,
+                report_descriptor: ReportDescriptor::StaticDescriptor(report_descriptor),
                 report_descriptor_length: u16::try_from(report_descriptor.len())
                     .map_err(|_| UsbHidBuilderError::SliceLengthOverflow)?,
                 description: None,


### PR DESCRIPTION
new method `InterfaceBuilder::with_static_descriptor` to allow static descriptors with > 128 bytes of data. Dynamic descriptors are now rejected at runtime if > 128 bytes rather than failing silently.