### PR TITLE
Corrections to comments on report descriptors

### DIFF
--- a/src/device/consumer.rs
+++ b/src/device/consumer.rs
@@ -20,7 +20,7 @@ pub const MULTIPLE_CODE_REPORT_DESCRIPTOR: &[u8] = &[
     0x26, 0x9C, 0x02, //     Logical Maximum(0x029C)
     0x19, 0x00, //     Usage Minimum(0)
     0x2A, 0x9C, 0x02, //     Usage Maximum(0x029C)
-    0x81, 0x00, //     Input (Array, Data, Variable)
+    0x81, 0x00, //     Input (Data, Array)
     0xC0, // End Collection
 ];
 

--- a/src/device/joystick.rs
+++ b/src/device/joystick.rs
@@ -11,7 +11,7 @@ pub const JOYSTICK_DESCRIPTOR: &[u8] = &[
     0x05, 0x01, // Usage Page (Generic Desktop)         5,   1
     0x09, 0x04, // Usage (Joystick)                     9,   4
     0xa1, 0x01, // Collection (Application)             161, 1
-    0x09, 0x01, //   Usage Page (Pointer)               9,   1
+    0x09, 0x01, //   Usage (Pointer)                    9,   1
     0xa1, 0x00, //   Collection (Physical)              161, 0
     0x09, 0x30, //     Usage (X)                        9,   48
     0x09, 0x31, //     Usage (Y)                        9,   49
@@ -22,7 +22,7 @@ pub const JOYSTICK_DESCRIPTOR: &[u8] = &[
     0x81, 0x02, //     Input (Data, Variable, Absolute) 129, 2,
     0xc0,       //   End Collection                     192,
     0x05, 0x09, //   Usage Page (Button)                5,   9,
-    0x19, 0x01, //   Usage Minimum (0)                  25,  1,
+    0x19, 0x01, //   Usage Minimum (1)                  25,  1,
     0x29, 0x08, //   Usage Maximum (8)                  41,  8,
     0x15, 0x00, //   Logical Minimum (0)                21,  0
     0x25, 0x01, //   Logical Maximum (1)                37,  1,

--- a/src/device/multiaxis.rs
+++ b/src/device/multiaxis.rs
@@ -11,7 +11,7 @@ pub const MULTIAXIS_DESCRIPTOR: &[u8] = &[
     0x05, 0x01, // Usage Page (Generic Desktop)         5,   1
     0x09, 0x08, // Usage (multi-axis Controller)        9,   8
     0xa1, 0x01, // Collection (Application)             161, 1
-    0x09, 0x01, //   Usage Page (Pointer)               9,   1
+    0x09, 0x01, //   Usage (Pointer)                    9,   1
     0xa1, 0x00, //   Collection (Physical)              161, 0
     0x09, 0x30, //     Usage (X)                        9,   48
     0x09, 0x31, //     Usage (Y)                        9,   49
@@ -26,7 +26,7 @@ pub const MULTIAXIS_DESCRIPTOR: &[u8] = &[
     0x81, 0x02, //     Input (Data, Variable, Absolute) 129, 2,
     0xc0,       //   End Collection                     192,
     0x05, 0x09, //   Usage Page (Button)                5,   9,
-    0x19, 0x01, //   Usage Minimum (0)                  25,  1,
+    0x19, 0x01, //   Usage Minimum (1)                  25,  1,
     0x29, 0x08, //   Usage Maximum (8)                  41,  8,
     0x15, 0x00, //   Logical Minimum (0)                21,  0
     0x25, 0x01, //   Logical Maximum (1)                37,  1,


### PR DESCRIPTION
While testing a prototype [report-descriptor encoder/decoder](https://codeberg.org/ericseppanen/usb-hid-utils) against some of the report descriptors in this crate, I found a few places where the comments don't match the bytes.
